### PR TITLE
- add argparse-based entry so python -m py_file_organizer.main accept…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,57 @@
 # Py File Organizer
 
-Organize automaticamente arquivos em pastas baseadas na extensao, mantendo seus diretórios sempre limpos.
+Automatically sort your files into folders based on their extension and keep your directories tidy.
 
-## Visao geral
-- Detecta a extensao de cada arquivo e move para a pasta correspondente definida em `py_file_organizer/extensions.py`.
-- Interface em modo texto usando `console-menu` para facilitar o uso.
-- Tratamento de erros basico para diretórios inexistentes ou ja organizados.
+## Overview
+- Detects every file extension and moves the file to the matching folder defined in `py_file_organizer/extensions.py`.
+- Ships with a console-menu based interface so you can run it interactively.
+- Provides basic error handling for missing or already organized directories.
 
-## Pre-requisitos
-- Python 3.8 ou superior.
-- `pip` configurado no PATH.
-- Ambiente virtual (opcional, mas recomendado).
+## Prerequisites
+- Python 3.8 or newer.
+- `pip` available on your PATH.
+- A virtual environment is optional but recommended.
 
-## Como configurar o ambiente
+## Environment setup
 ```bash
-# clone o repositorio
+# clone the repository
 git clone https://github.com/silviooosilva/Py-File-Organizer.git
 cd Py-File-Organizer
 
-# (opcional) crie e ative um ambiente virtual
+# (optional) create and activate a virtual environment
 python3 -m venv .venv
 source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
 
-# dependencias do aplicativo
+# application dependencies
 pip install -r requirements.txt
 
-# dependencias para desenvolvimento e testes
+# development and testing dependencies
 pip install -r requirements_dev.txt
 ```
 
-## Como executar o organizador
+## How to run the organizer
 ```bash
 python3 -m py_file_organizer.main
+# or pass the target directory directly
+python3 -m py_file_organizer.main /path/to/directory
 ```
-O programa abre um menu interativo. Escolha `Start App`, cole o caminho absoluto do diretorio que deseja organizar e confirme. As pastas sao criadas conforme o mapeamento definido em `py_file_organizer/extensions.py`.
+Without arguments the program opens an interactive menu: choose `Start App`, paste the absolute path of the directory you want to organize, and confirm. When you supply the directory as a CLI argument the organization runs immediately, which is handy for automation. Folders are created according to the mapping in `py_file_organizer/extensions.py`.
 
-## Testes e manutencao de qualidade
-### Testes unitarios
+## Testing and quality checks
+### Unit tests
 ```bash
 python3 -m pytest tests/ -v
 ```
-Ou utilize o atalho com relatorio de cobertura:
+Or use the Makefile shortcut with coverage:
 ```bash
 make tests
 ```
 
-### Testes comportamentais (BDD)
+### BDD scenarios
 ```bash
 python3 -m pytest bdd/ -v
 ```
-Ou ainda:
+Or run:
 ```bash
 make bdd
 ```
@@ -58,23 +60,23 @@ make bdd
 ```bash
 flake8 .
 ```
-(O comando `make lint` executa os testes com cobertura e, em seguida, roda o lint.)
+(The `make lint` command runs the tests with coverage first and then executes flake8.)
 
-## Estrutura do projeto
+## Project layout
 ```
 py_file_organizer/
-├── main.py            # Interface interativa baseada em console-menu
-├── functions.py       # Regras de organizacao de arquivos
-├── extensions.py      # Mapeamento de extensoes para pastas
+├── main.py            # Console-menu interface and CLI entrypoint
+├── functions.py       # File organization logic
+├── extensions.py      # Extension-to-folder mapping
 └── __init__.py
 ```
-Os testes unitarios vivem em `tests/` e os cenarios comportamento em `bdd/`. Imagens de demonstracao estao em `demo/`.
+Unit tests live in `tests/`, BDD scenarios in `bdd/`, and demo screenshots in `demo/`.
 
-## Contribuindo
-Sinta-se a vontade para abrir issues ou pull requests. Antes de enviar mudancas, execute os testes (`make tests`) e o lint (`flake8 .`) para garantir que tudo continua funcionando.
+## Contributing
+Feel free to open issues or pull requests. Before submitting changes, run the test suite (`make tests`) and the linter (`flake8 .`) to ensure everything still works.
 
-## Licenca
-Distribuido sob a licenca MIT. Consulte `LICENSE` para mais detalhes.
+## License
+Released under the MIT License. See `LICENSE` for details.
 
-## Autor
-Projeto criado por Silvio Silva.
+## Author
+Project created by Silvio Silva.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 ### Highlights
 - Rewrote the project README with updated setup, execution, and testing instructions to match the current workflow.
 - Documented optional virtual environment usage and separated runtime dependencies from development-only tooling.
-- Clarified how to run the interactive console menu (`python3 -m py_file_organizer.main`) and outlined the extension mapping in `py_file_organizer/extensions.py`.
+ - Clarified how to run the interactive console menu (`python3 -m py_file_organizer.main`), documented the new command-line directory parameter, and outlined the extension mapping in `py_file_organizer/extensions.py`.
 - Added explicit guidance for running unit tests, BDD scenarios, and linting through both raw commands and Makefile shortcuts.
 
 ### Fixed / Improved

--- a/py_file_organizer/main.py
+++ b/py_file_organizer/main.py
@@ -1,19 +1,49 @@
+import argparse
+import os
+import sys
+
 from colorama import Fore
 # noinspection PyPackageRequirements
 from consolemenu import ConsoleMenu
 # noinspection PyPackageRequirements
 from consolemenu.items import FunctionItem
 
-if __package__ in {None, ''}:
-    import os
-    import sys
-
+if __package__ in {None, ''}:  # pragma: no cover - allow running as `python main.py`
     package_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if package_root not in sys.path:
         sys.path.insert(0, package_root)
-    from py_file_organizer import functions
-else:
-    from . import functions
+    from py_file_organizer import functions  # type: ignore
+else:  # pragma: no cover
+    from . import functions  # type: ignore
+
+
+def _parse_args(arguments=None):
+    parser = argparse.ArgumentParser(
+        description='Organize files into folders based on their extensions.'
+    )
+    parser.add_argument(
+        'directory',
+        nargs='?',
+        help='Directory to organize. When omitted, the interactive menu is shown.',
+    )
+    return parser.parse_args(arguments if arguments is not None else [])
+
+
+def _organize_directory(path: str, wait_callback=None):
+    organizer = functions.PyFileOrganizer(path)
+    if hasattr(organizer, '_check_dir') and not organizer._check_dir():
+        if wait_callback is not None:
+            wait_callback()
+        return False
+    organizer.run()
+    if wait_callback is not None:
+        wait_callback()
+    return True
+
+
+def _print_farewell():
+    print("[!] Enjoy :) Bye")
+    print(f'{Fore.YELLOW}By: Sílvio Silva')
 
 
 class PyFileOrganizerUI:
@@ -43,24 +73,25 @@ class PyFileOrganizerUI:
 
     def on_start_app(self):
         path = str(input('Paste the directory location: '))
-        organizer = functions.PyFileOrganizer(path)
-        if not organizer._check_dir():
-            self._wait_user()
-            return
-        organizer.run()
-        self._wait_user()
+        _organize_directory(path, wait_callback=self._wait_user)
 
     def on_info(self):
         print('« Go To : https://github.com/silviooosilva/Py-File-Organizer »')
         self._wait_user()
 
 
-def main():
+def main(argv=None):
+    args = _parse_args(argv)
+    if args.directory:
+        success = _organize_directory(args.directory)
+        _print_farewell()
+        return 0 if success else 1
+
     app = PyFileOrganizerUI()
     app.run()
-    print("[!] Enjoy :) Bye")
-    print(f'{Fore.YELLOW}By: Sílvio Silva')
+    _print_farewell()
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,9 +74,11 @@ def test_on_start_app(mock_wait_user,
                       mock_input):
     ui = PyFileOrganizerUI()
     mock_input.return_value = 'path'
+    mock_py_file_organizer.return_value._check_dir.return_value = True
     ui.on_start_app()
     mock_input.assert_called_once_with('Paste the directory location: ')
     mock_py_file_organizer.assert_called_once_with('path')
+    mock_py_file_organizer()._check_dir.assert_called_once_with()
     mock_py_file_organizer().run.assert_called_once_with()
 
     mock_wait_user.assert_called_once_with()
@@ -96,9 +98,33 @@ def test_on_info(mock_wait_user, mock_print):
 @patch(prefixed('print'))
 def test_main(mock_print, mock_py_file_organizer_ui):
     from py_file_organizer.main import main
-    main()
+    exit_code = main([])
     mock_py_file_organizer_ui.assert_called_once_with()
     mock_py_file_organizer_ui().run.assert_called_once_with()
     mock_print.has_calls([
         call("[!] Enjoy :) Bye"),
         call(f'{Fore.YELLOW}By: Sílvio Silva')])
+    assert exit_code == 0
+
+
+@patch(prefixed('PyFileOrganizerUI'))
+@patch(prefixed('functions.PyFileOrganizer'))
+@patch(prefixed('print'))
+def test_main_with_directory(mock_print,
+                             mock_py_file_organizer,
+                             mock_py_file_organizer_ui):
+    from py_file_organizer.main import main
+
+    instance = mock_py_file_organizer.return_value
+    instance._check_dir.return_value = True
+
+    exit_code = main(['some/path'])
+
+    mock_py_file_organizer.assert_called_once_with('some/path')
+    instance._check_dir.assert_called_once_with()
+    instance.run.assert_called_once_with()
+    mock_py_file_organizer_ui.assert_not_called()
+    mock_print.has_calls([
+        call("[!] Enjoy :) Bye"),
+        call(f'{Fore.YELLOW}By: Sílvio Silva')])
+    assert exit_code == 0


### PR DESCRIPTION
- add argparse-based entry so python -m py_file_organizer.main accepts an optional directory argument and reuse it from the interactive menu
- factor helpers for organization and farewell messages to keep CLI and UI paths consistent
- expand unit tests to cover new helpers, exit codes, and CLI usage
- document the argument in the README and release notes and keep the whole README in English for consistency